### PR TITLE
print mash results to a TSV file

### DIFF
--- a/centroid.py
+++ b/centroid.py
@@ -62,6 +62,10 @@ def Mash_List_Maker(input_assembly_list):
             String1 = subprocess.check_output('mash dist ' + files + ' ' + files2, shell=True)
             Output.append(String1)
     Output.sort()
+    # write TSV to file
+    with open("mash-results.tsv", 'w', newline='') as tsvfile:
+        for item in Output:
+            tsvfile.write(item.decode("utf-8"))
     return Output
 
 def Mash_Centroid(input_assembly_list):

--- a/centroid.py
+++ b/centroid.py
@@ -8,12 +8,14 @@
 #Requires: mash
 #Usage: python centroid.py /path/to/assemblies/
 
+VERSION = "0.1.0"
 import sys
 import glob
 import numpy
 import operator
 from operator import itemgetter
 import subprocess
+import argparse
 
 def Mash_List(Mash_Index):
     """Takes in an index of Mash files and makes a list of the info from each"""
@@ -75,7 +77,18 @@ def Mash_Centroid(input_assembly_list):
     Best = Averages[0][0]
     return Best
 
-Folder = sys.argv[1]
+
+parser = argparse.ArgumentParser(
+    description = '''Selects optimal reference genome given a set of fasta files''',
+    usage = 'centroid.py [options] /path/to/fasta_files/',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    
+parser.add_argument('folder',  help='Folder containing *.fasta files', type=str)
+parser.add_argument('--version', action='version', version=str(VERSION))
+options = parser.parse_args()
+
+
+Folder = options.folder
 Assembly_List = glob.glob(Folder + '/*.fasta')
 Centroid = Mash_Centroid(Assembly_List)
 print(Centroid)


### PR DESCRIPTION
Hey Rachael, I tried out Centroid today and was curious to see "behind the curtain" for how the centroid genome is chosen from a set of genomes. 

So here's a simple little PR that does the following:
- takes the rows of `Output` which is tab-delimited already
- uses `.decode("utf-8")` to strip off the byte encoding from each row
- adds the rows to a file called `mash-output.tsv`

I'm not a pythonista, so there may be some non-best practice code 😬 , but this works for me and creates a TSV as expected:

```bash
# 5 assemblies
$ ls asms/
SAMN19774594_contigs.fasta  SAMN19774612_contigs.fasta  SAMN19774623_contigs.fasta  SAMN19774642_contigs.fasta  SAMN19774644_contigs.fasta

# run centroid on dir of assemblies
$ python3 ~/github/centroid-kapsakcj-fork/centroid.py asms/
Sketching asms/SAMN19774644_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774644_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774644_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774644_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774644_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774594_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774594_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774594_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774594_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774594_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774612_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774612_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774612_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774612_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774612_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774642_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774642_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774642_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774642_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774642_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774623_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774623_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774623_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774623_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
Sketching asms/SAMN19774623_contigs.fasta (provide sketch file made with "mash sketch" to skip)...done.
b'asms/SAMN19774594_contigs.fasta'

# show centroid out file
$ cat centroid_out.txt 
SAMN19774594_contigs.fasta

# show mash-results.tsv but with nice tabular-aware spacing
$ column -t -s $'\t' -n mash-results.tsv 
asms/SAMN19774594_contigs.fasta  asms/SAMN19774594_contigs.fasta  0            0  1000/1000
asms/SAMN19774594_contigs.fasta  asms/SAMN19774612_contigs.fasta  0.000361208  0  985/1000
asms/SAMN19774594_contigs.fasta  asms/SAMN19774623_contigs.fasta  0.00390583   0  854/1000
asms/SAMN19774594_contigs.fasta  asms/SAMN19774642_contigs.fasta  0.0023533    0  908/1000
asms/SAMN19774594_contigs.fasta  asms/SAMN19774644_contigs.fasta  0.00294054   0  887/1000
asms/SAMN19774612_contigs.fasta  asms/SAMN19774594_contigs.fasta  0.000361208  0  985/1000
asms/SAMN19774612_contigs.fasta  asms/SAMN19774612_contigs.fasta  0            0  1000/1000
asms/SAMN19774612_contigs.fasta  asms/SAMN19774623_contigs.fasta  0.00408721   0  848/1000
asms/SAMN19774612_contigs.fasta  asms/SAMN19774642_contigs.fasta  0.00210772   0  917/1000
asms/SAMN19774612_contigs.fasta  asms/SAMN19774644_contigs.fasta  0.00308338   0  882/1000
asms/SAMN19774623_contigs.fasta  asms/SAMN19774594_contigs.fasta  0.00390583   0  854/1000
asms/SAMN19774623_contigs.fasta  asms/SAMN19774612_contigs.fasta  0.00408721   0  848/1000
asms/SAMN19774623_contigs.fasta  asms/SAMN19774623_contigs.fasta  0            0  1000/1000
asms/SAMN19774623_contigs.fasta  asms/SAMN19774642_contigs.fasta  0.00433199   0  840/1000
asms/SAMN19774623_contigs.fasta  asms/SAMN19774644_contigs.fasta  0.00384578   0  856/1000
asms/SAMN19774642_contigs.fasta  asms/SAMN19774594_contigs.fasta  0.0023533    0  908/1000
asms/SAMN19774642_contigs.fasta  asms/SAMN19774612_contigs.fasta  0.00210772   0  917/1000
asms/SAMN19774642_contigs.fasta  asms/SAMN19774623_contigs.fasta  0.00433199   0  840/1000
asms/SAMN19774642_contigs.fasta  asms/SAMN19774642_contigs.fasta  0            0  1000/1000
asms/SAMN19774642_contigs.fasta  asms/SAMN19774644_contigs.fasta  0.00375609   0  859/1000
asms/SAMN19774644_contigs.fasta  asms/SAMN19774594_contigs.fasta  0.00294054   0  887/1000
asms/SAMN19774644_contigs.fasta  asms/SAMN19774612_contigs.fasta  0.00308338   0  882/1000
asms/SAMN19774644_contigs.fasta  asms/SAMN19774623_contigs.fasta  0.00384578   0  856/1000
asms/SAMN19774644_contigs.fasta  asms/SAMN19774642_contigs.fasta  0.00375609   0  859/1000
asms/SAMN19774644_contigs.fasta  asms/SAMN19774644_contigs.fasta  0            0  1000/1000
```